### PR TITLE
iOS: replace Textual with Down for markdown rendering

### DIFF
--- a/server/go.sum
+++ b/server/go.sum
@@ -3,8 +3,6 @@ github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/emergent-company/emergent.memory/apps/server/pkg/sdk v0.40.73 h1:FtgUmMMFlZpikPmLIhWygs/VYl16R/15tsQMzGjDMJ8=
-github.com/emergent-company/emergent.memory/apps/server/pkg/sdk v0.40.73/go.mod h1:7dtjFLeSIXNj9J1M2tqNBqqTeDr9MXwpNbF/p0a35TU=
 github.com/emergent-company/emergent.memory/apps/server/pkg/sdk v0.41.52 h1:MpFGLwtcOU8xjbtoKrunu5igg5/2fUh7RY/70MmmduI=
 github.com/emergent-company/emergent.memory/apps/server/pkg/sdk v0.41.52/go.mod h1:7dtjFLeSIXNj9J1M2tqNBqqTeDr9MXwpNbF/p0a35TU=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=

--- a/server/swift/Packages/DianeShared/Package.resolved
+++ b/server/swift/Packages/DianeShared/Package.resolved
@@ -1,39 +1,21 @@
 {
   "pins" : [
     {
+      "identity" : "down",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/johnxnguyen/Down",
+      "state" : {
+        "revision" : "f34b166be1f1db4aa8f573067e901d72f2a6be57",
+        "version" : "0.11.0"
+      }
+    },
+    {
       "identity" : "sentry-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
         "revision" : "cf44aa8cb4147f39e698c1f28be0b6b2c89f79d2",
         "version" : "8.58.2"
-      }
-    },
-    {
-      "identity" : "swift-concurrency-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
-      "state" : {
-        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
-        "version" : "1.3.2"
-      }
-    },
-    {
-      "identity" : "swiftui-math",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/swiftui-math",
-      "state" : {
-        "revision" : "0b5c2cfaaec8d6193db206f675048eeb5ce95f71",
-        "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "textual",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/textual",
-      "state" : {
-        "revision" : "5b06b811c0f5313b6b84bbef98c635a630638c38",
-        "version" : "0.3.1"
       }
     }
   ],

--- a/server/swift/Packages/DianeShared/Package.swift
+++ b/server/swift/Packages/DianeShared/Package.swift
@@ -11,13 +11,13 @@ let package = Package(
         .library(name: "DianeShared", targets: ["DianeShared"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/gonzalezreal/textual", from: "0.3.1"),
+        .package(url: "https://github.com/johnxnguyen/Down", from: "0.11.0"),
     ],
     targets: [
         .target(
             name: "DianeShared",
             dependencies: [
-                .product(name: "Textual", package: "textual", condition: .when(platforms: [.macOS, .iOS])),
+                .product(name: "Down", package: "Down"),
             ]
         ),
         .testTarget(

--- a/server/swift/Packages/DianeShared/Sources/Utilities/DianeContentDetector.swift
+++ b/server/swift/Packages/DianeShared/Sources/Utilities/DianeContentDetector.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Down
 
 // MARK: - Content Type Detection
 
@@ -78,19 +79,21 @@ public struct DianeContentDetector: Sendable {
     }
 }
 
-// MARK: - Markdown to AttributedString
+// MARK: - Markdown to HTML
 
 extension String {
-    /// Convert markdown to an AttributedString.
-    /// Apple's parser is very lenient — it will succeed for plain text too.
-    public func toMarkdownAttributed() -> AttributedString? {
-        try? AttributedString(
-            markdown: self,
-            options: .init(
-                allowsExtendedAttributes: true,
-                interpretedSyntax: .full
-            )
-        )
+    /// Convert markdown to HTML using Down (cmark).
+    /// Returns a complete HTML document wrapped for WebView rendering.
+    public func markdownToHTML(isUser: Bool = false) -> String {
+        guard !isEmpty else { return "" }
+        do {
+            let down = Down(markdownString: self)
+            let html = try down.toHTML()
+            return html.htmlWrappedForWebView(darkMode: true, isUser: isUser)
+        } catch {
+            // Fallback: render plain text in a paragraph if markdown parsing fails
+            return "<p>\(self)</p>".htmlWrappedForWebView(darkMode: true, isUser: isUser)
+        }
     }
 }
 
@@ -98,14 +101,33 @@ extension String {
 
 extension String {
     /// Wraps the content in a minimal HTML document for WKWebView rendering.
-    /// Includes dark mode support and base styling.
-    public func htmlWrappedForWebView(darkMode: Bool = false) -> String {
+    /// Includes dark mode support, base styling, and bubble-aware colors for user messages.
+    public func htmlWrappedForWebView(darkMode: Bool = false, isUser: Bool = false) -> String {
         let htmlContent = self
-        let bgColor = darkMode ? "#1C1C1E" : "#FFFFFF"
-        let textColor = darkMode ? "#E5E5E5" : "#1C1C1E"
-        let linkColor = darkMode ? "#64A8FF" : "#007AFF"
-        let codeBg = darkMode ? "#2C2C2E" : "#F2F2F7"
-        let codeColor = darkMode ? "#E5E5E5" : "#1C1C1E"
+        let bgColor: String
+        let textColor: String
+        let linkColor: String
+        let codeBg: String
+        let codeColor: String
+        if isUser {
+            bgColor = "#007AFF" // accentColor
+            textColor = "#FFFFFF"
+            linkColor = "#FFFFFF"
+            codeBg = "#0055CC"
+            codeColor = "#E5E5E5"
+        } else if darkMode {
+            bgColor = "#1C1C1E"
+            textColor = "#E5E5E5"
+            linkColor = "#64A8FF"
+            codeBg = "#2C2C2E"
+            codeColor = "#E5E5E5"
+        } else {
+            bgColor = "#FFFFFF"
+            textColor = "#1C1C1E"
+            linkColor = "#007AFF"
+            codeBg = "#F2F2F7"
+            codeColor = "#1C1C1E"
+        }
 
         return """
         <!DOCTYPE html>

--- a/server/swift/Packages/DianeShared/Sources/Views/MessageContentView.swift
+++ b/server/swift/Packages/DianeShared/Sources/Views/MessageContentView.swift
@@ -1,16 +1,12 @@
 import SwiftUI
 
-#if canImport(Textual)
-import Textual
-#endif
-
 // MARK: - Message Content View
 
 /// A shared content view that renders message content with intelligent content detection.
 ///
 /// Supports three content types:
 /// - **HTML**: Renders in a WKWebView with auto-sizing and dark mode support
-/// - **Markdown**: Renders with Textual (when available) or AttributedString fallback
+/// - **Markdown**: Renders via Down → HTML → WKWebView
 /// - **Plain text**: Rendered as-is with `.font(.body)` and `.textSelection(.enabled)`
 ///
 /// Detection is automatic via `DianeContentDetector`, but can be overridden
@@ -79,36 +75,10 @@ public struct MessageContentView: View {
 
     @ViewBuilder
     private var markdownView: some View {
-        #if canImport(Textual)
-        if #available(iOS 18.0, macOS 15.0, *) {
-            textualMarkdownView
-        } else {
-            attributedMarkdownView
-        }
-        #else
-        attributedMarkdownView
-        #endif
-    }
-
-    #if canImport(Textual)
-    @ViewBuilder
-    private var textualMarkdownView: some View {
-        StructuredText(markdown: content)
-            .textual.textSelection(.enabled)
-            .textual.structuredTextStyle(.default)
-            .font(.subheadline)
-    }
-    #endif
-
-    @ViewBuilder
-    private var attributedMarkdownView: some View {
-        if let attributed = content.toMarkdownAttributed() {
-            Text(attributed)
-                .font(.subheadline)
-                .textSelection(.enabled)
-        } else {
-            plainView
-        }
+        HTMLWebView(htmlContent: content.markdownToHTML(isUser: isUser), dynamicHeight: $htmlHeight)
+            .frame(height: max(htmlHeight, 50))
+            .frame(maxWidth: .infinity)
+            .textSelection(.enabled)
     }
 
     // MARK: - Plain


### PR DESCRIPTION
## Problem

Two crash/hang issues on iOS 26.4.2 traced to Textual (StructuredText) markdown rendering:

- **APPLE-IOS-E**: AttributeGraph stack overflow (EXC_BREAKPOINT) during view graph update when entering ChatView
- **APPLE-IOS-H**: AppHang in `OpenTypeShapingEngine` during rapid keyboard/layout cycling

Both involve SwiftUI text rendering via Textual's `StructuredText(markdown:)`.

## Solution

Replace Textual v0.3.1 with [Down](https://github.com/johnxnguyen/Down) v0.11.0:

1. Convert markdown to HTML via Down's cmark parser (GFM-compliant)
2. Render in existing HTMLWebView (WKWebView with auto-sizing)
3. Updated htmlWrappedForWebView to support user-bubble styling (accent bg + white text)

## Files changed

- DianeShared/Package.swift — Textual → Down dependency swap
- DianeShared/Sources/Views/MessageContentView.swift — markdownView now uses Down → HTMLWebView
- DianeShared/Sources/Utilities/DianeContentDetector.swift — added markdownToHTML(), removed toMarkdownAttributed()
- DianeShared/Package.resolved — auto-updated

## Verification

- macOS companion app builds and runs cleanly ✅
- iOS code compiles (signing blocked on mcj-mini, needs CI build)

Fixes APPLE-IOS-E, APPLE-IOS-H, APPLE-IOS-G